### PR TITLE
drop double quotes around default value, as they cause the actual output files to have double quotes around their names

### DIFF
--- a/bin/ansible-inventory-grapher
+++ b/bin/ansible-inventory-grapher
@@ -16,7 +16,7 @@ def options_parser():
                       default=os.getcwd())
     parser.add_option('--format', dest='format',
                       help='python format string to name output files [%default]',
-                      default='"{hostname}.dot"')
+                      default='{hostname}.dot')
     return parser
 
 


### PR DESCRIPTION
Before:
    -rw-r--r--    1 peter  admin   289 Apr  3 14:32 "pdnsdev.dot"

After:
    -rw-r--r--    1 peter  admin   289 Apr  3 14:31 pdnsdev.dot
