### PR TITLE
Smallfixes

### DIFF
--- a/bin/ansible-inventory-grapher
+++ b/bin/ansible-inventory-grapher
@@ -54,7 +54,7 @@ def generate_graph(pattern, options):
     inventory = ansible.inventory.Inventory(options.inventory)
     hostnames = inventory.list_hosts(pattern)
     if not hostnames:
-        print "No hosts matched for pattern %s" % hostname
+        print "No hosts matched for pattern %s" % pattern
         return
     if not os.path.exists(options.directory):
         os.makedirs(options.directory)


### PR DESCRIPTION
- improved on defaults for parser options
- removed double quotes from file names (files were generated litterally `"msb-pr-1.dot"`)
- bugfix: `hostname` is not a known variable
- removed discontinued record option from dot file, works with dot - graphviz version 2.26.3 (20100126.1600), should be checked on other versions?
