### PR TITLE
Pure graphviz template

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pip install ansible-inventory-grapher
 Usage: ansible-inventory-grapher [options] pattern1 [pattern2...]
 
 Options:
-  --version             show program's version number and exit
+  --version             show program\'s version number and exit
   -h, --help            show this help message and exit
   -i INVENTORY          specify inventory host file [/etc/ansible/hosts]
   -d DIRECTORY          Location to output resulting files [current directory]
@@ -37,22 +37,24 @@ Options:
 Using the example inventory in https://github.com/willthames/ansible-ec2-example,
 we can generate the dot files for two of the example web servers using:
 ```bash
-bin/ansible-inventory-grapher -i ../ansible-ec2-example/inventory/hosts prod-web-server-78a prod-web-server-28a -d test --format "test-{hostname}.dot"
+bin/ansible-inventory-grapher -i ../ansible-ec2-example/inventory/hosts \
+  prod-web-server-78a prod-web-server-28a \
+  -d test --format "test-{hostname}.dot"
 ```
 
-You can add the `-a` option to insert a string with graphviz attributes to apply to the root level of the graph.  Some fun examples:
+You can add the `-a` option to insert a string with graphviz attributes (http://www.graphviz.org/doc/info/attrs.html) to apply to the root level of the graph.  Some fun examples:
 ```bash
 # transpose the tree so it grows from left-right instead of top-bottom
 -a "rankdir=LR;"
 
-# circular layout, with groups shaded grey
+# circular layout, with group nodes shaded grey
 -a "layout=circo; overlap=false; splines=polyline;\
-node [ style=filled fillcolor=lightgrey ]"
+  node [ style=filled fillcolor=lightgrey ]"
 
 # OCD
 -a "rankdir=LR; splines=ortho; ranksep=2;\
-node [ width=5 style=filled fillcolor=lightgrey ];\
-edge [ dir=back arrowtail=empty ];"
+  node [ width=5 style=filled fillcolor=lightgrey ];\
+  edge [ dir=back arrowtail=empty ];"
 ```
 
 You can replace the default template (which can be seen by passing the `-T` variable to `ansible-inventory-grapher`) with a template file that can be
@@ -68,7 +70,8 @@ for f in test/*.dot ; do dot -Tpng -o test/`basename $f .dot`.png $f; done
 Or the whole thing can now be done in one pipeline (only works for one pattern) 
 straight to image viewer (imagemagick's display in this example)
 ```bash
-bin/ansible-inventory-grapher -i ../ansible-ec2-example/inventory/hosts prod-web-server-1a | dot -Tpng | display png:-
+bin/ansible-inventory-grapher -i ../ansible-ec2-example/inventory/hosts \
+  prod-web-server-1a | dot -Tpng | display png:-
 ```
 
 This works with valid Ansible patterns now although only hosts and groups have been tested.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ bin/ansible-inventory-grapher -i ../ansible-ec2-example/inventory/hosts \
   -d test --format "test-{hostname}.dot"
 ```
 
-You can add the `-a` option to insert a string with graphviz attributes (http://www.graphviz.org/doc/info/attrs.html) to apply to the root level of the graph.  Some fun examples:
+## Customization
+
+You can generate different types of graph by using the `-a` option to insert a string with graphviz attributes (http://www.graphviz.org/doc/info/attrs.html) to apply to the root level of the graph.  Some fun examples:
 ```bash
 # transpose the tree so it grows from left-right instead of top-bottom
 -a "rankdir=LR;"
@@ -57,8 +59,50 @@ You can add the `-a` option to insert a string with graphviz attributes (http://
   edge [ dir=back arrowtail=empty ];"
 ```
 
-You can replace the default template (which can be seen by passing the `-T` variable to `ansible-inventory-grapher`) with a template file that can be
-passed with the `-t` option.
+You can replace the entire default template (which can be seen by passing the
+`-T` variable to `ansible-inventory-grapher`) with a template file
+that can be passed with the `-t` option.
+```bash
+cat << EOF > html_table_nodes.dot.j2
+digraph {{pattern|labelescape}} {
+  {{ attributes }}
+
+{% for node in nodes|sort(attribute='name') %}
+  {{ node.name|labelescape }} [shape=record
+  {{- " style=rounded" if node.leaf }} label=<
+<table border="0" cellborder="0">
+  <tr><td {%- if node.leaf %} href="ssh://{{ node.name|labelescape }}"{% endif -%} >
+  <b><font face="Times New Roman, Bold" point-size="16">
+  {{ node.name }}
+  </font></b></td></tr>
+{% if node.vars and showvars %}
+  <hr/><tr><td><font face="Times New Roman, Bold" point-size="14">
+{% for var in node.vars|sort %}
+  {{var}}<br/>
+{% endfor %}
+  </font></td></tr>
+{% endif %}
+</table>
+>]
+
+{% endfor %}
+
+{% for edge in edges|sort(attribute='source') %}
+  {{ edge.source|labelescape }} -> {{ edge.target|labelescape }};
+{% endfor %}
+}
+EOF
+
+bin/ansible-inventory-grapher -t html_table_nodes.dot.j2 -i ./test/inventory/hosts all > all.dot \
+  && dot -Tsvg all.dot > all.svg
+```
+
+as an aside, SVG output can be nice, since you can open it in a
+browser to search and copy/paste text, as well as activate link URLs
+to open your nodes in ssh: (as in the sample above) or embed links to
+those nodes / groups in your monitoring site.
+
+## Render Pipeline
 
 The resulting graphs can then be converted to pngs using:
 ```bash

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ pip install ansible-inventory-grapher
 ```
 
 ## Usage
-```bash
+```
 Usage: ansible-inventory-grapher [options] pattern1 [pattern2...]
 
 Options:
-  --version             show program\'s version number and exit
+  --version             show program's version number and exit
   -h, --help            show this help message and exit
   -i INVENTORY          specify inventory host file [/etc/ansible/hosts]
   -d DIRECTORY          Location to output resulting files [current directory]

--- a/README.md
+++ b/README.md
@@ -7,38 +7,59 @@ Requires:
 * graphviz
 
 ## Getting started
-```
+```bash
 pip install ansible-inventory-grapher
 ```
 
 ## Usage
-```
+```bash
 Usage: ansible-inventory-grapher [options] pattern1 [pattern2...]
 
 Options:
+  --version             show program's version number and exit
   -h, --help            show this help message and exit
-  -i INVENTORY          specify inventory host file
-                        [/Users/will/.ansible/hosts]
+  -i INVENTORY          specify inventory host file [/etc/ansible/hosts]
   -d DIRECTORY          Location to output resulting files [current directory]
   -o FORMAT, --format=FORMAT
-                        python format string to name output files (e.g. {}.dot) 
-                        [defaults to stdout]
+                        python format string to name output files (e.g.
+                        {}.dot) [defaults to stdout]
   -q, --no-variables    Turn off variable display in default template
   -t TEMPLATE           path to jinja2 template used for creating output
   -T                    print default template
+  -a ATTRIBUTES         include top-level graphviz attributes from
+                        http://www.graphviz.org/doc/info/attrs.html
+                        [rankdir=TB;]
+  --ask-vault-pass      prompt for vault password
+  --vault-password-file=VAULT_PASSWORD_FILE
+                        Location of file with cleartext vault password
 ```
 
 Using the example inventory in https://github.com/willthames/ansible-ec2-example,
 we can generate the dot files for two of the example web servers using:
-```
+```bash
 bin/ansible-inventory-grapher -i ../ansible-ec2-example/inventory/hosts prod-web-server-78a prod-web-server-28a -d test --format "test-{hostname}.dot"
+```
+
+You can add the `-a` option to insert a string with graphviz attributes to apply to the root level of the graph.  Some fun examples:
+```bash
+# transpose the tree so it grows from left-right instead of top-bottom
+-a "rankdir=LR;"
+
+# circular layout, with groups shaded grey
+-a "layout=circo; overlap=false; splines=polyline;\
+node [ style=filled fillcolor=lightgrey ]"
+
+# OCD
+-a "rankdir=LR; splines=ortho; ranksep=2;\
+node [ width=5 style=filled fillcolor=lightgrey ];\
+edge [ dir=back arrowtail=empty ];"
 ```
 
 You can replace the default template (which can be seen by passing the `-T` variable to `ansible-inventory-grapher`) with a template file that can be
 passed with the `-t` option.
 
 The resulting graphs can then be converted to pngs using:
-```
+```bash
 for f in test/*.dot ; do dot -Tpng -o test/`basename $f .dot`.png $f; done
 ```
 
@@ -46,7 +67,7 @@ for f in test/*.dot ; do dot -Tpng -o test/`basename $f .dot`.png $f; done
 
 Or the whole thing can now be done in one pipeline (only works for one pattern) 
 straight to image viewer (imagemagick's display in this example)
-```
+```bash
 bin/ansible-inventory-grapher -i ../ansible-ec2-example/inventory/hosts prod-web-server-1a | dot -Tpng | display png:-
 ```
 

--- a/bin/ansible-inventory-grapher
+++ b/bin/ansible-inventory-grapher
@@ -33,10 +33,9 @@ from ansibleinventorygrapher.version import __version__
 
 
 DEFAULT_TEMPLATE = """digraph {{pattern|labelescape}} {
-{% for edge in edges %}
-  {{ edge.source|labelescape }} -> {{ edge.target|labelescape }};
-{% endfor %}
-{% for node in nodes %}
+  rankdir = LR; {# LR = left->right ; TB = top->bottom #}
+
+{% for node in nodes|sort(attribute='name') %}
 {% if node.leaf %}
   {{ node.name|labelescape }} [shape=record style=rounded label=<
 <table border="0" cellborder="0">
@@ -56,8 +55,12 @@ DEFAULT_TEMPLATE = """digraph {{pattern|labelescape}} {
 </table>
 >]
 {% endif %}{% endfor %}
-}
 
+{% for edge in edges|sort(attribute='source') %}
+  {{ edge.source|labelescape }} -> {{ edge.target|labelescape }};
+{% endfor %}
+
+}
 """
 
 

--- a/bin/ansible-inventory-grapher
+++ b/bin/ansible-inventory-grapher
@@ -34,7 +34,7 @@ from ansibleinventorygrapher.version import __version__
 
 
 DEFAULT_TEMPLATE = """digraph {{pattern|labelescape}} {
-  rankdir = LR; {# LR = left->right ; TB = top->bottom #}
+  {{ attributes }}
 
 {% for node in nodes|sort(attribute='name') %}
 {% if node.leaf %}
@@ -84,6 +84,10 @@ def options_parser():
                       help='path to jinja2 template used for creating output')
     parser.add_option('-T', dest='print_template', action="store_true",
                       help='print default template')
+    parser.add_option('-a', dest='attributes',
+                      help='include top-level graphviz attributes from ' +
+                      'http://www.graphviz.org/doc/info/attrs.html [%default]',
+                      default='rankdir=TB;')
     parser.add_option('--ask-vault-pass', dest='ask_vault_pass', action="store_true",
                       help="prompt for vault password", default=False)
     parser.add_option('--vault-password-file', dest='vault_password_file',
@@ -138,6 +142,7 @@ def render_graph(pattern, options):
         edges |= host_edges
         nodes |= host_nodes
     output = template.render(edges=edges, nodes=nodes, pattern=pattern,
+                             attributes=options.attributes,
                              showvars=options.showvars)
     if options.format != '-':
         filename = options.format.format(pattern)

--- a/bin/ansible-inventory-grapher
+++ b/bin/ansible-inventory-grapher
@@ -33,29 +33,21 @@ import ansibleinventorygrapher
 from ansibleinventorygrapher.version import __version__
 
 
-DEFAULT_TEMPLATE = """digraph {{pattern|labelescape}} {
+DEFAULT_TEMPLATE = """digraph {{ pattern|labelescape }} {
   {{ attributes }}
 
 {% for node in nodes|sort(attribute='name') %}
-{% if node.leaf %}
-  {{ node.name|labelescape }} [shape=record style=rounded label=<
-<table border="0" cellborder="0">
-  <tr><td><b>
-  <font face="Times New Roman, Bold" point-size="16">{{ node.name}}</font>
-  </b></td></tr>
-{% if node.vars and showvars %}<hr/><tr><td><font face="Times New Roman, Bold" point-size="14">{% for var in node.vars|sort %}{{var}}<br/>{%endfor %}</font></td></tr>{% endif %}
-</table>
->]
-{% else %}
-  {{ node.name|labelescape }} [shape=record label=<
-<table border="0" cellborder="0">
-  <tr><td><b>
-  <font face="Times New Roman, Bold" point-size="16">{{ node.name}}</font>
-  </b></td></tr>
-{% if node.vars and showvars %}<hr/><tr><td><font face="Times New Roman, Bold" point-size="14">{% for var in node.vars|sort %}{{var}}<br/>{%endfor %}</font></td></tr>{% endif %}
-</table>
->]
-{% endif %}{% endfor %}
+  {{ node.name|labelescape }} [shape=record
+  {{- " style=rounded" if node.leaf }} label="
+{ {{ node.name }}
+{%- if node.vars and showvars %} |
+{% for var in node.vars|sort %}
+{{ var }} \l
+{% endfor -%}
+{% endif %}
+} "]
+
+{% endfor %}
 
 {% for edge in edges|sort(attribute='source') %}
   {{ edge.source|labelescape }} -> {{ edge.target|labelescape }};

--- a/lib/ansibleinventorygrapher/__init__.py
+++ b/lib/ansibleinventorygrapher/__init__.py
@@ -23,7 +23,7 @@ _parents = dict()
 _vars = dict()
 
 
-class Edge:
+class Edge(object):
     def __init__(self, source, target):
         self.source = source
         self.target = target
@@ -37,8 +37,7 @@ class Edge:
     def __hash__(self):
         return hash(self.source + self.target)
 
-
-class Node:
+class Node(object):
     def __init__(self, name, vars={}, leaf=False):
         self.name = name
         self.leaf = leaf


### PR DESCRIPTION
So I was playing around with the OCD layout trying to get all the vars left-justified, and graphviz's html subset just wasn't fully honoring the align="left" declarations anywhere, so I ended up stripping all of the html out.  This gets everything lined up nicely, but the tradeoff is that we lose the fine font control. :/

This should probably just be a separate template, but I thought since it was so much simpler, it might serve as a better default template to use as a starting point for people making custom templates.  I cleaned up the html default template a bit and added it to the README as an example for an "advanced" custom template.   Could just as easily reverse that if you'd like to stick with the current html default template, though... let me know!