### PR TITLE
put dot labels into quotes

### DIFF
--- a/bin/ansible-inventory-grapher
+++ b/bin/ansible-inventory-grapher
@@ -105,7 +105,7 @@ def options_parser():
 
 
 def labelescape(name):
-    return name.replace("-", "_").replace(".", "_")
+    return "\"%s\"" % name.replace("-", "_").replace(".", "_")
 
 
 def load_template(options):


### PR DESCRIPTION
This puts all labelnames into quotes. This is necessary for inventories that contain ip adresses and should in general not be harmful.

This happened to me:
```

$ ansible-inventory-grapher -i home "all" | dot -oinv.png -Tpng
Warning: syntax ambiguity - badly delimited number '141_' in line 4 of <stdin> splits into two tokens
Warning: syntax ambiguity - badly delimited number '192_' in line 11 of <stdin> splits into two tokens
Warning: syntax ambiguity - badly delimited number '192_' in line 18 of <stdin> splits into two tokens
Warning: syntax ambiguity - badly delimited number '192_' in line 25 of <stdin> splits into two tokens
Warning: syntax ambiguity - badly delimited number '192_' in line 32 of <stdin> splits into two tokens
Warning: syntax ambiguity - badly delimited number '192_' in line 39 of <stdin> splits into two tokens
...
```