### PR TITLE
Change error message output to stderr

### DIFF
--- a/bin/ansible-inventory-grapher
+++ b/bin/ansible-inventory-grapher
@@ -121,7 +121,7 @@ def render_graph(pattern, options):
     hosts = inventory_mgr.inventory.list_hosts(pattern)
     template = load_template(options)
     if not hosts:
-        print("No hosts matched for pattern %s" % pattern)
+        print("No hosts matched for pattern %s" % pattern, file=sys.stderr)
         return
     if not os.path.exists(options.directory):
         os.makedirs(options.directory)


### PR DESCRIPTION
Don't mislead following tools in a shell pipe in case of an empty requested group in an inventory.