### PR TITLE
Add no-hosts option to prevent display of hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Options:
                         python format string to name output files (e.g.
                         {}.dot) [defaults to stdout]
   -q, --no-variables    Turn off variable display in default template
+  -n, --no-hosts        Turn off display of hosts
   -t TEMPLATE           path to jinja2 template used for creating output
   -T                    print default template
   -a ATTRIBUTES         include top-level graphviz attributes from

--- a/lib/ansibleinventorygrapher/__init__.py
+++ b/lib/ansibleinventorygrapher/__init__.py
@@ -105,12 +105,18 @@ def tidy_all_the_variables(host, inventory_mgr):
     return _vars
 
 
-def generate_graph_for_host(host, inventory_mgr):
+def generate_graph_for_host(host, inventory_mgr, include_host):
     # dedup graph edges
     edges = set(parent_graphs(host, host.groups))
     vars = tidy_all_the_variables(host, inventory_mgr)
     nodes = set()
-    nodes.add(Node(host.name, vars=vars[host], leaf=True))
+
+    if include_host:
+        nodes.add(Node(host.name, vars=vars[host], leaf=True))
+    else:
+        for edge in edges.copy():
+            if edge.target == host.name:
+                edges.remove(edge)
 
     for group in host.get_groups():
         nodes.add(Node(group.name, vars=vars[group]))

--- a/lib/ansibleinventorygrapher/__main__.py
+++ b/lib/ansibleinventorygrapher/__main__.py
@@ -75,6 +75,9 @@ def options_parser():
     parser.add_option('-q', '--no-variables', dest='showvars',
                       action="store_false", default=True,
                       help="Turn off variable display in default template")
+    parser.add_option('-n', '--no-hosts', dest='showhosts',
+                      action="store_false", default=True,
+                      help="Turn off display of hosts")
     parser.add_option('-t', dest='template',
                       help='path to jinja2 template used for creating output')
     parser.add_option('-T', dest='print_template', action="store_true",
@@ -135,7 +138,7 @@ def render_graph(pattern, options):
     nodes = set()
     for host in hosts:
         try:
-            (host_edges, host_nodes) = ansibleinventorygrapher.generate_graph_for_host(host, inventory_mgr)
+            (host_edges, host_nodes) = ansibleinventorygrapher.generate_graph_for_host(host, inventory_mgr, options.showhosts)
         except ansibleinventorygrapher.inventory.NoVaultSecretFound:
             raise SystemExit("Couldn't find a secret to decrypt vaulted file(s)")
         edges |= host_edges


### PR DESCRIPTION
Thanks for the project!
In my use case, I'm trying to visualise the group hierarchy of an inventory, by passing "*" as the host pattern.
Because the resulting graph includes all hosts, it is difficult to ascertain group relationships.